### PR TITLE
Add gatsby-source-mathdroid-covid19 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 
 - [https://github.com/pabloVinicius/covid-19-dashboard](https://github.com/pabloVinicius/covid-19-dashboard) [https://covid19.data.eti.br/](https://covid19.data.eti.br/), (Web) by [Pablo Vinicius](https://github.com/pabloVinicius)
 
+- [https://github.com/freakyfelt/gatsby-source-mathdroid-covid19](https://github.com/freakyfelt/gatsby-source-mathdroid-covid19)(https://github.com/freakyfelt/gatsby-source-mathdroid-covid19), (Gatsby, TypeScript) by [Bruce Felt](https://github.com/freakyfelt)
 
 ## License
 


### PR DESCRIPTION
I've written a plugin for [Gatsby](https://www.gatsbyjs.org/) that massages the results into GraphQL nodes. I also wrote an APIClient in TypeScript that could be of use to people looking to consume the data from other JS repos