### PR TITLE
Fix /api/countries/[country]/og Does not work when window 64 bit install Chrome 64 bit

### DIFF
--- a/util/options.ts
+++ b/util/options.ts
@@ -1,7 +1,9 @@
 import chrome from "chrome-aws-lambda";
 const exePath =
   process.platform === "win32"
-    ? "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
+    ? process.arch === "x64" // add additional check to see if win is 64 or 32 bit
+    ? "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe" 
+    : "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
     : process.platform === "linux"
     ? "/usr/bin/chromium-browser"
     : "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";

--- a/util/options.ts
+++ b/util/options.ts
@@ -2,8 +2,8 @@ import chrome from "chrome-aws-lambda";
 const exePath =
   process.platform === "win32"
     ? process.arch === "x64" // add additional check to see if win is 64 or 32 bit
-    ? "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe" 
-    : "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+    ? "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+    : "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe" 
     : process.platform === "linux"
     ? "/usr/bin/chromium-browser"
     : "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";

--- a/util/template.ts
+++ b/util/template.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from "fs";
 
 const regularInter = readFileSync(
-  `${__dirname}/../../../fonts/Inter-Regular.woff2`
+  `${__dirname}/../fonts/Inter-Regular.woff2`
 ).toString("base64");
 const boldInter = readFileSync(
-  `${__dirname}/../../../fonts/Inter-Bold.woff2`
+  `${__dirname}/../fonts/Inter-Bold.woff2`
 ).toString("base64");
 
 function formatNumber(num: number): string {


### PR DESCRIPTION
##what?
pull request fixes for #461

##why? 
1. it seemed that exePath in util/options does not include cases when chrome 64bit is install in window 64
2. util/template.ts regularInter refer to path outside of project directory  

##how?
1. add check for window64 and path to chrome.exe 
2. change path of regularInter in util/template.ts to point to fonts directory inside the project

##sreenshot 
after fixes on window 64 with chrome 64 installation
![image](https://user-images.githubusercontent.com/48720253/125398890-39ba4980-e3f3-11eb-8300-f337c0e70db5.png)
 
